### PR TITLE
Add bare-p test for bare repositories

### DIFF
--- a/package.lisp
+++ b/package.lisp
@@ -86,6 +86,7 @@
   (:export
    #:repository
    #:git-location-p
+   #:bare-p
    #:init
    #:clone
    #:fetch

--- a/repository.lisp
+++ b/repository.lisp
@@ -44,6 +44,13 @@
   (= 0 (with-chdir (location)
          (git-rev-parse NIL :git-dir T))))
 
+(defgeneric bare-p (repository &key &allow-other-keys)
+  (:method ((repository pathname) &key)
+    (= 1 (with-chdir (repository)
+           (git-rev-parse NIL :is-bare-repository T))))
+  (:method ((repository repository) &key)
+    (bare-p (pathname (location repository)))))
+
 (defgeneric init (repository &key &allow-other-keys)
   (:method ((repository pathname) &key (if-does-not-exist :error) remote branch bare)
     (unless (git-location-p repository)


### PR DESCRIPTION
Shinmera/autobuild@f4facdd6b46db4f916f5c667ffefc945955e4ef7 seems to rely on legit implementing and exporting a `bare-p`.