### PR TITLE
Fixed loading of legit on LispWorks

### DIFF
--- a/repository.lisp
+++ b/repository.lisp
@@ -233,7 +233,7 @@
      (loop
        for line = (read-line in nil nil)
        while line
-       for last-slash-position = (position #\slash line :from-end t)
+       for last-slash-position = (position #\solidus line :from-end t)
        when last-slash-position
          collect (subseq line (1+ last-slash-position)))
      :test #'string=)))

--- a/repository.lisp
+++ b/repository.lisp
@@ -233,7 +233,7 @@
      (loop
        for line = (read-line in nil nil)
        while line
-       for last-slash-position = (position #\solidus line :from-end t)
+       for last-slash-position = (position #\/ line :from-end t)
        when last-slash-position
          collect (subseq line (1+ last-slash-position)))
      :test #'string=)))


### PR DESCRIPTION
LispWorks does not know what #\slash is but (char-name #\/) returns "Solidus".